### PR TITLE
Standardize public package documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-# v2.0.4
+# v3.0.0
+
+- Added Laravel 12 component constraints and compatible dependency generations.
+- The release declares Laravel 8 through Laravel 12 constraints; a complete compatibility matrix was not included in this release.
+
+## v2.0.4
 
 - Added highlighted text for email notification
 - Add functionality to search child tables via advanced search

--- a/README.md
+++ b/README.md
@@ -12,8 +12,18 @@ A Laravel scaffolding package for an opinionated Laravel coding style.
 
 ## REQUIREMENTS
 
-- PHP 8.2+
-- Laravel 11+
+The published v3.0.0 package declares:
+
+- PHP 7.3 or newer.
+- Laravel 8 through Laravel 12 component constraints.
+
+These values describe the published Composer constraints. They do not imply that every PHP/Laravel combination has been verified by a version matrix. Review the constraints of the exact package version selected by Composer.
+
+## SOURCE AND RELEASE POLICY
+
+Development, tests, feature branches, and pull requests are maintained in the private `ikechukwukalu/magic-make` development source repository. This public repository is the release destination for reviewed package versions.
+
+Documentation in this repository describes published behavior. Planned generation profiles, modular target paths and namespaces, safer initialization, conflict preflight, and explicit response modes remain unreleased until a separately authorized package synchronization and release.
 
 ## STEPS TO INSTALL
 


### PR DESCRIPTION
## What changed

- adds the missing v3.0.0 changelog entry
- aligns the requirements section with the published Composer constraints
- distinguishes declared constraints from verified compatibility
- documents the development-source and public-release repository roles
- marks planned safety, profile, modular-generation, and response-mode work as unreleased

## Why

The public README claimed PHP 8.2+ and Laravel 11+ while the published v3.0.0 Composer metadata declares PHP 7.3+ and Laravel 8–12 component constraints. The changelog also stopped at v2.0.4.

## Impact

Documentation only. No Composer metadata, package source, tag, release, publication, or synchronization change is included.

## Validation

- Markdown diff check passed
- changed files are limited to `README.md` and `CHANGELOG.md`